### PR TITLE
Stop the Spongemock command from doubling digits.

### DIFF
--- a/FruitBowlBot/Commands/SpongebobPluginCommand.cs
+++ b/FruitBowlBot/Commands/SpongebobPluginCommand.cs
@@ -95,7 +95,7 @@ namespace JefBot.Commands
                 for (int i = 0; i < input.Length; i++)
                 {
                     int r = rng.Next(1, 3);
-                    if (i != 0)
+                    if (i != 0 && input[i].IsDigit() == false)
                     {
                         if (input[i] == char.ToUpper(input[i]))
                             temp += char.ToLower(input[i]);
@@ -117,7 +117,7 @@ namespace JefBot.Commands
                 for (int i = 0; i < input.Length; i++)
                 {
                     int r = rng.Next(1, 3);
-                    if (i != 0)
+                    if (i != 0 && input[i].IsDigit() == false)
                     {
                         if (input[i] == char.ToUpper(input[i]))
                             temp += char.ToLower(input[i]);


### PR DESCRIPTION
This should stop the Spongemock command from doubling digits as in this example:

[9:52 PM] calrogman: !bob 12345678901234567890
[9:52 PM] BOTFBB: [meme.jpg]
123445677890012334556788900